### PR TITLE
Allow numerical keys for class arrays

### DIFF
--- a/.changeset/honest-ravens-draw.md
+++ b/.changeset/honest-ravens-draw.md
@@ -1,0 +1,15 @@
+---
+"attr": minor
+---
+
+Allow numerical keys for 'class' arrays:
+
+```php
+attr([
+  'class' => [
+    'foo bar',
+    'baz' => true,
+    'qux' => false
+  ]
+])
+```

--- a/.changeset/honest-ravens-draw.md
+++ b/.changeset/honest-ravens-draw.md
@@ -7,7 +7,7 @@ Allow numerical keys for 'class' arrays:
 ```php
 attr([
   'class' => [
-    'foo bar',
+    'foo bar', // <-- now supported
     'baz' => true,
     'qux' => false
   ]

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -24,7 +24,7 @@ if (! \function_exists('attr')) {
      *   attr(['type' => 'button'])->class('active', when: $isActive)
      *
      * @param array{
-     *      class?: string|array<string, int|bool|null>,
+     *      class?: string|array<int|string, string|int|bool|null>,
      *      style?: string|array<string, string|int|float|false|null>,
      * }|array<string, string|int|float|bool|null>|null $attributes
      */

--- a/tests/Feature/AttrTest.php
+++ b/tests/Feature/AttrTest.php
@@ -123,6 +123,12 @@
     ])->toString();
 })->throws(InvalidArgumentException::class);
 
+\test('throws if provided with a non-string value for numeric class keys', function () {
+    \attr([
+        'class' => [true],
+    ])->toString();
+})->throws(InvalidArgumentException::class);
+
 \test('throws if provided with a string for nested class values', function () {
     \attr([
         'class' => [

--- a/tests/Feature/AttrTest.php
+++ b/tests/Feature/AttrTest.php
@@ -5,6 +5,11 @@
     \expect($result)->toBe(' class="border border-red bg-black" ');
 });
 
+\test('allows numeric key, string as value for "class"', function () {
+    $result = (string) \attr(['class' => ['border border-red bg-black']]);
+    \expect($result)->toBe(' class="border border-red bg-black" ');
+});
+
 \test('supports boolean attributes', function () {
     $result = (string) \attr([
         'data-current' => true,
@@ -69,14 +74,13 @@
 })->throws(InvalidArgumentException::class);
 
 \test('throws when provided with a non-associative array for the "style" attribute', function () {
-    // @phpstan-ignore argument.type
     \attr(['style' => ['foo', 'bar']])->toString();
 })->throws(InvalidArgumentException::class);
 
-\test('throws when provided with a non-associative array for the "class" attribute', function () {
-    // @phpstan-ignore argument.type
-    \attr(['class' => ['foo', 'bar']])->toString();
-})->throws(InvalidArgumentException::class);
+\test('allows a non-associative array for the "class" attribute', function () {
+    $result = (string) \attr(['class' => ['foo', 'bar']]);
+    \expect($result)->toBe(' class="foo bar" ');
+});
 
 \test('throws when provided with a nested array for any attribute', function () {
     // @phpstan-ignore argument.type


### PR DESCRIPTION
```php
attr([
  'class' => [
    'foo bar', // <-- now supported 
    'baz' => true,
    'qux' => false
  ]
])
```